### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gym-super-mario
 #### **Gym Super Mario is an environment bundle for OpenAI Gym**
 ---
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/gym-super-mario)](https://repl.it/github/UzayAnil/gym-super-mario)
 <div id="installation"></div>Installation
 ============
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).